### PR TITLE
Barra espaciadora para saltar intros

### DIFF
--- a/Scenes/splash/splash_screen.gd
+++ b/Scenes/splash/splash_screen.gd
@@ -7,22 +7,32 @@ const MAIN_MENU_PATH := "res://Scenes/UI/main_menu.tscn"
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
 @export var music: AudioStream
 
+var animations: Array[StringName] = ["logos", "logoPixel"]
+var skip_spamming_locked: bool = false
+
 func _ready() -> void:
+	animation_player.animation_finished.connect(_on_animation_player_animation_finished)
 	MusicPlayer.play(music, true)
 	
-	
-	
+	animation_player.stop()
+	animation_player.clear_queue()
+	for a in animations:
+		animation_player.queue(a)
+
+func _process(_delta: float) -> void:
+	if Input.is_action_just_pressed("spacebar") && !skip_spamming_locked:
+		skip_spamming_locked = true
+		animation_player.seek(animation_player.current_animation_length - 0.01)
+		get_tree().create_timer(0.5).timeout.connect(
+			func(): skip_spamming_locked = false
+		)
 
 func _play_swoosh() -> void:
 	SFXPlayer.play(swoosh)
 	
-
 func _play_appear() -> void:
 	SFXPlayer.play(ghost_appear)
 
 func _on_animation_player_animation_finished(anim_name: StringName) -> void:
-	if anim_name == "logos":
-		animation_player.play("logoPixel")
-	
 	if anim_name == "logoPixel":
 		get_tree().change_scene_to_file(MAIN_MENU_PATH)

--- a/Scenes/splash/splash_screen.tscn
+++ b/Scenes/splash/splash_screen.tscn
@@ -268,5 +268,3 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 metadata/_edit_lock_ = true
-
-[connection signal="animation_finished" from="AnimationPlayer" to="." method="_on_animation_player_animation_finished"]

--- a/project.godot
+++ b/project.godot
@@ -70,6 +70,11 @@ pause={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":80,"key_label":0,"unicode":112,"location":0,"echo":false,"script":null)
 ]
 }
+spacebar={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
 
 [input_devices]
 


### PR DESCRIPTION
Probando agregar una feature simple para ver que tengo permisos funcionales en git.
Agregué la barra espaciadora al mapa de inputs, reconecté una señal e hice que las animaciones estén encoladas, para poder saltearlaras haciendo seek()
No me parece lo ideal hacerle un "adelantar" para saltear una animación, pero funciona, ya que si usás stop y play no triggerea la señal de AnimationPlayer.animation_finished
De paso queda listo para que sea más fácil agregar futuras animaciones al inicio si hay que poner más logos o mensajes